### PR TITLE
Updating to linkml 0.0.7, otherwise fails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-linkml >= 0.0.6
+linkml >= 0.0.7
 mkdocs


### PR DESCRIPTION
0.0.6 does not have the gen-markdown command